### PR TITLE
Replacing link from S3 with cloudinary hosting

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -19,6 +19,7 @@ const config = {
   images: {
     domains: [
       "uavalidator-images.s3.eu-central-1.amazonaws.com",
+      "res.cloudinary.com",
     ]
   }
 };


### PR DESCRIPTION
NEXT_PUBLIC_IMAGE_BUCKET_URL=https://res.cloudinary.com/ua-validator/image/upload/v1681587262/images
